### PR TITLE
Remove __future__.annotations

### DIFF
--- a/akcli/main.py
+++ b/akcli/main.py
@@ -4,8 +4,6 @@
 Main entry point for the CLI application.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
This import was causing that Annotated types not being parsed by Typer in Python 3.9.

Closes #37.