### PR TITLE
feat: Add support for dig raw output

### DIFF
--- a/akcli/commands/dig.py
+++ b/akcli/commands/dig.py
@@ -11,7 +11,7 @@ import typer
 from typing_extensions import Annotated
 
 from ..config import Config
-from ..exceptions import DigNoAnswerWarning, handle_exceptions
+from ..exceptions import DigNoAnswerWarning, MutuallyExclusiveArgs, handle_exceptions
 from ..utils import create_table, highlight, print_json
 from ._common import common_args
 
@@ -60,6 +60,10 @@ def dig(
     query_type: Annotated[
         _DNSType, typer.Option(help="Choose type of query.")
     ] = config.query_type,  # type: ignore
+    raw: Annotated[
+        bool,
+        typer.Option(help="Print dig raw response (just like regular `dig` command)."),
+    ] = config.raw,
     short: Annotated[
         bool, typer.Option(help="Show only returned values.")
     ] = config.short_output,
@@ -70,6 +74,10 @@ def dig(
     api = ctx.obj.api
     console = ctx.obj.console
 
+    # Raise error if --raw and --json used simultaneously
+    if raw and ctx.params.get("json"):
+        raise MutuallyExclusiveArgs("'--raw' and '--json' are mutually exclusive.")
+
     response = api.dig(hostname, query_type)
     answer_section = response.result.answer_section
 
@@ -79,7 +87,12 @@ def dig(
         )
         raise typer.Exit()
 
-    if ctx.params.get("json"):
+    if raw:
+        raw_dig = response.result.raw_dig
+        console.print(raw_dig)
+        raise typer.Exit()
+
+    elif ctx.params.get("json"):
         print_json(console, response.model_dump(by_alias=True))
         raise typer.Exit()
 

--- a/akcli/config.py
+++ b/akcli/config.py
@@ -42,6 +42,7 @@ _DEFAULT_REQUEST_TIMEOUT = 15
 _DEFAULT_VALIDATE_CERTS = True
 
 _DEFAULT_DIG_QUERY_TYPE = "A"
+_DEFAULT_DIG_RAW = False
 _DEFAULT_DIG_SHORT_OUTPUT = False
 
 _DEFAULT_TRANSLATE_TRACE = False
@@ -101,6 +102,7 @@ class _DigOptions(_OptionsBase):
     """
 
     query_type: str = _DEFAULT_DIG_QUERY_TYPE
+    raw: bool = _DEFAULT_DIG_RAW
     short_output: bool = _DEFAULT_DIG_SHORT_OUTPUT
 
 
@@ -126,8 +128,8 @@ class Config:
     _instance = None
 
     """
-    NOTE: Declare commands options at class level allows `dataclasses.get_type_hints()` 
-    to automatically discover all commands and their type. This helps to validate config file 
+    NOTE: Declare commands options at class level allows `dataclasses.get_type_hints()`
+    to automatically discover all commands and their type. This helps to validate config file
     parameters without needing to hardcode the valid sections/options.
     """
 

--- a/akcli/exceptions.py
+++ b/akcli/exceptions.py
@@ -35,7 +35,7 @@ class _BaseException(Exception):
     exit_code = 99
     default_msg = "An error occurred"
 
-    def __init__(self, msg: Optional[str] = None) -> None:
+    def __init__(self, msg: Optional[str] = None, *args, **kwargs) -> None:
         _exception_name = type(self).__name__
 
         self.msg = (
@@ -45,7 +45,7 @@ class _BaseException(Exception):
                 self, "default_msg", f"{_exception_name}: {type(self).default_msg}"
             )
         )
-        super().__init__(self.msg)
+        super().__init__(self.msg, *args, **kwargs)
 
     def __repr__(self) -> str:
         """
@@ -160,6 +160,13 @@ class InvalidPanelType(HandledException):
 
     exit_code = 61
     default_msg = "Invalid panel type specified."
+
+
+class MutuallyExclusiveArgs(HandledException):
+    """Raised if mutually exclusive arguments are used together."""
+
+    exit_code = 62
+    default_msg = "Mutually exclusive arguments."
 
 
 # ----------------------

--- a/tests/integration/test_dig.py
+++ b/tests/integration/test_dig.py
@@ -137,3 +137,26 @@ def test_response_in_json_format(https_server, edgerc, runner, hostname, cache_d
     assert "result" in result.output
     assert "example.com" in result.output
     assert "recordType" in result.output
+
+
+def test_response_with_raw_and_json_flags(
+    https_server, edgerc, runner, hostname, cache_dir
+):
+    """
+    Test that using --raw and --json simultaneously produces an error.
+    """
+    cmd = [
+        "--edgerc",
+        edgerc,
+        "--cache-dir",
+        cache_dir,
+        "--no-validate-certs",
+        "dig",
+        hostname,
+        "--raw",
+        "--json",
+    ]
+    result = runner.invoke(app, cmd)
+
+    assert result.exit_code != 0
+    assert "MutuallyExclusiveArgs" in result.output


### PR DESCRIPTION
Now `dig` subcommand may be invoked with the flag --raw to print the output as the same way that regular `dig` does. No tables, no fancy output.
Closes #10.